### PR TITLE
Added place holder to auto generated element

### DIFF
--- a/src/list-input.js
+++ b/src/list-input.js
@@ -451,9 +451,11 @@ angular.module('ui.listInput', [])
 				transcludedInput.eq(transcludedInput.length - 1).attr('ng-blur', 'updateItems()');
 			}
 			else {
-				// The transcluded content did not have an input, so create one.
+				// The transcluded content did not have an input, so create.
+				// add a placeholder
+				var placholdercontent = 'placeholder="'+attributes.placeholder+'"'
 				if (transcludedInput.length === 0) {
-					transcludedInput = angular.element('<input name="listItem" type="text" class="form-control" />');
+					transcludedInput = angular.element('<input name="listItem" type="text" class="form-control" '+placholdercontent+' />');
 				}
 
 				// Enforce a name for validation


### PR DESCRIPTION
Before this edit we can add placeholder-value to custom fields but using the ui list input with an auto-generated text element did not allow to add a placeholder simply because the auto generated element template was not complete with a placeholder.
Now after edit a user can add a placeholder attribute like in any HTML input in the main div beside ng-model attribute.
