### PR TITLE
npm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-ui-list-input",
+  "main": "dist/angular-ui-list-input.js",
   "version": "0.2.1",
   "devDependencies": {
     "bower": "~1.3.9",


### PR DESCRIPTION
PR adds npm support to package, required for browserify or similar bundlers.
